### PR TITLE
fix: Add 'object' to data type

### DIFF
--- a/src/Grid.vue
+++ b/src/Grid.vue
@@ -12,7 +12,7 @@ export default {
   name: 'TuiGrid',
   props: {
     data: {
-      type: Array,
+      type: [Array, Object],
       required: true
     },
     columns: {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
현재 props 중 'data' 의 형식이 'Array' 만 설정되어 있습니다.
하지만 'data' 의 형식은 [DataSource](https://github.com/nhn/tui.grid/blob/master/docs/en/data-source.md) 타입의 Object 도 가능합니다.
따라서 'data' 형식에 'Object' 를 추가합니다.

**ps. 관련된 Guide 문서 또한 업데이트가 필요합니다.
　　([README - props](https://github.com/nhn/toast-ui.vue-grid/blob/master/README.md#props), [GettingStarted - props](https://github.com/nhn/toast-ui.vue-grid/blob/master/docs/getting-started.md#props))**


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
